### PR TITLE
Prefix trait objects with dyn

### DIFF
--- a/derive/src/de.rs
+++ b/derive/src/de.rs
@@ -50,7 +50,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
             }
 
             impl #impl_generics miniserde::de::Visitor for __Visitor #ty_generics #bounded_where_clause {
-                fn map(&mut self) -> miniserde::Result<miniserde::export::Box<miniserde::de::Map + '_>> {
+                fn map(&mut self) -> miniserde::Result<miniserde::export::Box<dyn miniserde::de::Map + '_>> {
                     Ok(Box::new(__State {
                         #(
                             #fieldname: miniserde::Deserialize::default(),

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -172,7 +172,7 @@ impl<T: Deserialize> Deserialize for Box<T> {
                 Ok(())
             }
 
-            fn seq(&mut self) -> Result<Box<Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 let mut value = Box::new(None);
                 let ptr = careful!(&mut *value as &mut Option<T>);
                 Ok(Box::new(BoxSeq {
@@ -182,7 +182,7 @@ impl<T: Deserialize> Deserialize for Box<T> {
                 }))
             }
 
-            fn map(&mut self) -> Result<Box<Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
                 let mut value = Box::new(None);
                 let ptr = careful!(&mut *value as &mut Option<T>);
                 Ok(Box::new(BoxMap {
@@ -196,7 +196,7 @@ impl<T: Deserialize> Deserialize for Box<T> {
         struct BoxSeq<'a, T: 'a> {
             out: &'a mut Option<Box<T>>,
             value: Box<Option<T>>,
-            seq: Box<Seq + 'a>,
+            seq: Box<dyn Seq + 'a>,
         }
 
         impl<'a, T: Deserialize> Seq for BoxSeq<'a, T> {
@@ -214,7 +214,7 @@ impl<T: Deserialize> Deserialize for Box<T> {
         struct BoxMap<'a, T: 'a> {
             out: &'a mut Option<Box<T>>,
             value: Box<Option<T>>,
-            map: Box<Map + 'a>,
+            map: Box<dyn Map + 'a>,
         }
 
         impl<'a, T: Deserialize> Map for BoxMap<'a, T> {
@@ -270,12 +270,12 @@ impl<T: Deserialize> Deserialize for Option<T> {
                 Deserialize::begin(self.out.as_mut().unwrap()).float(n)
             }
 
-            fn seq(&mut self) -> Result<Box<Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).seq()
             }
 
-            fn map(&mut self) -> Result<Box<Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
                 self.out = Some(None);
                 Deserialize::begin(self.out.as_mut().unwrap()).map()
             }
@@ -288,7 +288,7 @@ impl<T: Deserialize> Deserialize for Option<T> {
 impl<A: Deserialize, B: Deserialize> Deserialize for (A, B) {
     fn begin(out: &mut Option<Self>) -> &mut Visitor {
         impl<A: Deserialize, B: Deserialize> Visitor for Place<(A, B)> {
-            fn seq(&mut self) -> Result<Box<Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 Ok(Box::new(TupleBuilder {
                     out: &mut self.out,
                     tuple: (None, None),
@@ -329,7 +329,7 @@ impl<A: Deserialize, B: Deserialize> Deserialize for (A, B) {
 impl<T: Deserialize> Deserialize for Vec<T> {
     fn begin(out: &mut Option<Self>) -> &mut Visitor {
         impl<T: Deserialize> Visitor for Place<Vec<T>> {
-            fn seq(&mut self) -> Result<Box<Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 Ok(Box::new(VecBuilder {
                     out: &mut self.out,
                     vec: Vec::new(),
@@ -372,7 +372,7 @@ impl<T: Deserialize> Deserialize for Vec<T> {
 impl<K: FromStr + Ord, V: Deserialize> Deserialize for BTreeMap<K, V> {
     fn begin(out: &mut Option<Self>) -> &mut Visitor {
         impl<K: FromStr + Ord, V: Deserialize> Visitor for Place<BTreeMap<K, V>> {
-            fn map(&mut self) -> Result<Box<Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
                 Ok(Box::new(MapBuilder {
                     out: &mut self.out,
                     map: BTreeMap::new(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -76,7 +76,7 @@
 //! struct MyVec<T>(Vec<T>);
 //!
 //! impl<T: Deserialize> Visitor for Place<MyVec<T>> {
-//!     fn seq(&mut self) -> Result<Box<Seq + '_>> {
+//!     fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
 //!         Ok(Box::new(VecBuilder {
 //!             out: &mut self.out,
 //!             vec: Vec::new(),
@@ -144,7 +144,7 @@
 //! }
 //!
 //! impl Visitor for Place<Demo> {
-//!     fn map(&mut self) -> Result<Box<Map + '_>> {
+//!     fn map(&mut self) -> Result<Box<dyn Map + '_>> {
 //!         // Like for sequences, we produce a builder that can hand out places
 //!         // to write one struct field at a time.
 //!         Ok(Box::new(DemoBuilder {
@@ -269,11 +269,11 @@ pub trait Visitor {
         Err(Error)
     }
 
-    fn seq(&mut self) -> Result<Box<Seq + '_>> {
+    fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
         Err(Error)
     }
 
-    fn map(&mut self) -> Result<Box<Map + '_>> {
+    fn map(&mut self) -> Result<Box<dyn Map + '_>> {
         Err(Error)
     }
 }

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -34,11 +34,11 @@ impl Visitor for Ignore {
         Ok(())
     }
 
-    fn seq(&mut self) -> Result<Box<Seq + '_>> {
+    fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
         Ok(Box::new(Ignore))
     }
 
-    fn map(&mut self) -> Result<Box<Map + '_>> {
+    fn map(&mut self) -> Result<Box<dyn Map + '_>> {
         Ok(Box::new(Ignore))
     }
 }

--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -43,8 +43,8 @@ struct Deserializer<'a, 'b> {
 }
 
 enum Layer<'a> {
-    Seq(Box<Seq + 'a>),
-    Map(Box<Map + 'a>),
+    Seq(Box<dyn Seq + 'a>),
+    Map(Box<dyn Map + 'a>),
 }
 
 impl<'a, 'b> Drop for Deserializer<'a, 'b> {
@@ -91,11 +91,11 @@ fn from_str_impl(j: &str, mut visitor: &mut Visitor) -> Result<()> {
                 None
             }
             SeqStart => {
-                let seq = careful!(visitor.seq()? as Box<Seq>);
+                let seq = careful!(visitor.seq()? as Box<dyn Seq>);
                 Some(Layer::Seq(seq))
             }
             MapStart => {
-                let map = careful!(visitor.map()? as Box<Map>);
+                let map = careful!(visitor.map()? as Box<dyn Map>);
                 Some(Layer::Map(map))
             }
         };

--- a/src/json/ser.rs
+++ b/src/json/ser.rs
@@ -38,8 +38,8 @@ struct Serializer<'a> {
 }
 
 enum Layer<'a> {
-    Seq(Box<Seq + 'a>),
-    Map(Box<Map + 'a>),
+    Seq(Box<dyn Seq + 'a>),
+    Map(Box<dyn Map + 'a>),
 }
 
 impl<'a> Drop for Serializer<'a> {

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -89,7 +89,7 @@ impl Deserialize for Value {
                 Ok(())
             }
 
-            fn seq(&mut self) -> Result<Box<Seq + '_>> {
+            fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 Ok(Box::new(ArrayBuilder {
                     out: &mut self.out,
                     array: Array::new(),
@@ -97,7 +97,7 @@ impl Deserialize for Value {
                 }))
             }
 
-            fn map(&mut self) -> Result<Box<Map + '_>> {
+            fn map(&mut self) -> Result<Box<dyn Map + '_>> {
                 Ok(Box::new(ObjectBuilder {
                     out: &mut self.out,
                     object: Object::new(),

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -100,8 +100,8 @@ pub enum Fragment<'a> {
     U64(u64),
     I64(i64),
     F64(f64),
-    Seq(Box<Seq + 'a>),
-    Map(Box<Map + 'a>),
+    Seq(Box<dyn Seq + 'a>),
+    Map(Box<dyn Map + 'a>),
 }
 
 /// Trait for data structures that can be serialized to a JSON string.


### PR DESCRIPTION
Miniserde doesn't support Rust versions older than 1.26.0, so this should be fine.