### PR TITLE
Add (De)Serialize support for simple enums.

### DIFF
--- a/derive/src/ser.rs
+++ b/derive/src/ser.rs
@@ -2,18 +2,21 @@ use crate::{attr, bound};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields, Ident};
+use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields, FieldsNamed, Ident, DataEnum};
 
 pub fn derive(input: DeriveInput) -> TokenStream {
-    let fields = match input.data {
+    match &input.data {
         Data::Struct(DataStruct {
-            fields: Fields::Named(fields),
+            fields: Fields::Named(ref fields),
             ..
-        }) => fields,
+        }) => derive_struct(&input, &fields),
+        Data::Enum(ref _enum) => derive_enum(&input, _enum),
         _ => panic!("currently only structs with named fields are supported"),
-    };
+    }
+}
 
-    let ident = input.ident;
+fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> TokenStream {
+    let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let dummy = Ident::new(
         &format!("_IMPL_MINISERIALIZE_FOR_{}", ident),
@@ -58,6 +61,47 @@ pub fn derive(input: DeriveInput) -> TokenStream {
                             )),
                         )*
                         _ => miniserde::export::None,
+                    }
+                }
+            }
+        };
+    })
+}
+
+fn derive_enum(input: &DeriveInput, _enum: &DataEnum) -> TokenStream {
+    if input.generics.lt_token.is_some() || input.generics.where_clause.is_some() {
+        panic!("Enums with generics are not supported");
+    }
+
+    let ident = &input.ident;
+    let dummy = Ident::new(
+        &format!("_IMPL_MINISERIALIZE_FOR_{}", ident),
+        Span::call_site(),
+    );
+
+    let var_idents = _enum.variants.iter().map(|variant| {
+        match variant.fields {
+            Fields::Unit => {},
+            _ => panic!(
+                "Invalid variant {}:  only simple enum variants without fields are supported", 
+                variant.ident,
+            ),
+        }
+        &variant.ident
+    });
+    let names = _enum.variants.iter().map(attr::name_of_variant);
+
+    TokenStream::from(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            impl miniserde::Serialize for #ident {
+                fn begin(&self) -> miniserde::ser::Fragment {
+                    match self {
+                        #(
+                            #ident::#var_idents => {
+                                miniserde::ser::Fragment::Str(std::borrow::Cow::Borrowed(#names))
+                            }
+                        )*
                     }
                 }
             }

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -1,8 +1,17 @@
 use miniserde::{json, Deserialize, Serialize};
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
+enum Tag {
+    A,
+    #[serde(rename = "renamedB")]
+    B,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
 struct Example {
     x: String,
+    t1: Tag,
+    t2: Tag,
     n: Nested,
 }
 
@@ -14,10 +23,12 @@ struct Nested {
 
 #[test]
 fn test_de() {
-    let j = r#" {"x": "X", "n": {"y": ["Y", "Y"]}} "#;
+    let j = r#" {"x": "X", "t1": "A", "t2": "renamedB", "n": {"y": ["Y", "Y"]}} "#;
     let actual: Example = json::from_str(j).unwrap();
     let expected = Example {
         x: "X".to_owned(),
+        t1: Tag::A,
+        t2: Tag::B,
         n: Nested {
             y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
             z: None,
@@ -30,12 +41,14 @@ fn test_de() {
 fn test_ser() {
     let example = Example {
         x: "X".to_owned(),
+        t1: Tag::A,
+        t2: Tag::B,
         n: Nested {
             y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
             z: None,
         },
     };
     let actual = json::to_string(&example);
-    let expected = r#"{"x":"X","n":{"y":["Y","Y"],"z":null}}"#;
+    let expected = r#"{"x":"X","t1":"A","t2":"renamedB","n":{"y":["Y","Y"],"z":null}}"#;
     assert_eq!(actual, expected);
 }


### PR DESCRIPTION
Only simple C-style enums are accepted.
Enums with fields, generics or where clauses are rejected.
The #[serde(rename)] attribute is respected.