### PR TITLE
fix: no_std in dep and unused use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           toolchain: ${{matrix.rust}}
       - run: cargo test
       - run: cargo test --no-default-features
+      - name: Build without std
+        run: |
+          rustup target add aarch64-unknown-none
+          cargo check \
+              --manifest-path tests/crate/Cargo.toml \
+              --target aarch64-unknown-none \
+              --no-default-features
+        if: matrix.rust == 'stable'
 
   msrv:
     name: Rust 1.31.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [workspace]
-members = ["derive"]
+members = ["derive", "tests/crate"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-itoa = "0.4.3"
+itoa = { version = "0.4.3", default-features = false }
 mini-internal = { version = "=0.1.14", path = "derive" }
 ryu = "1.0"
 
@@ -28,4 +28,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 default = ["std"]
-std = []
+std = ["itoa/std"]

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -2,7 +2,9 @@
 use crate::lib::hash::{BuildHasher, Hash};
 use crate::lib::mem;
 use crate::lib::str::FromStr;
-use crate::lib::{str, BTreeMap, Box, Default, String, ToOwned, Vec};
+#[cfg(feature = "std")]
+use crate::lib::Default;
+use crate::lib::{str, BTreeMap, Box, String, ToOwned, Vec};
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 

--- a/tests/crate/Cargo.toml
+++ b/tests/crate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "serde_json_test"
+name = "miniserde_test"
 version = "0.0.0"
 edition = "2018"
 publish = false

--- a/tests/crate/Cargo.toml
+++ b/tests/crate/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "serde_json_test"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[lib]
+path = "test.rs"
+
+[dependencies]
+miniserde = { path = "../..", default-features = false }
+
+[features]
+default = ["std"]
+std = ["miniserde/std"]

--- a/tests/crate/test.rs
+++ b/tests/crate/test.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub use miniserde::*;


### PR DESCRIPTION
Fix from #21, so sorry for this (issue is that it still pulls in std through itoa)