### PR TITLE
Resolve bare_trait_objects error (2021 edition)

### DIFF
--- a/derive/src/de.rs
+++ b/derive/src/de.rs
@@ -84,7 +84,7 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
                         #(
                             #fieldstr => miniserde::__private::Ok(miniserde::Deserialize::begin(&mut self.#fieldname)),
                         )*
-                        _ => miniserde::__private::Ok(miniserde::de::Visitor::ignore()),
+                        _ => miniserde::__private::Ok(<dyn miniserde::de::Visitor>::ignore()),
                     }
                 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -160,7 +160,7 @@
 //!         match k {
 //!             "code" => Ok(Deserialize::begin(&mut self.code)),
 //!             "message" => Ok(Deserialize::begin(&mut self.message)),
-//!             _ => Ok(Visitor::ignore()),
+//!             _ => Ok(<dyn Visitor>::ignore()),
 //!         }
 //!     }
 //!


### PR DESCRIPTION
This can be triggered when deriving Deserialize with rust 2021 edition:

```rust
use miniserde::Deserialize;

#[derive(Deserialize)]
struct A {
    a: (),
}

fn main() {}
```
yields

```bash
error[E0783]: trait objects without an explicit `dyn` are deprecated
 --> src/main.rs:3:10
  |
7 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^ help: use `dyn`: `<dyn Deserialize>`
  |
```