### PR TITLE
Added testcase for ignore() unsafety

### DIFF
--- a/tests/regression/issue24.rs
+++ b/tests/regression/issue24.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+use miniserde::{json, Deserialize};
+
+#[derive(Deserialize)]
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+#[test]
+fn main() {
+    let result = json::from_str::<Point>(r#"{"x": 1, "y": 2, "z": 3}"#);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
I noticed that there were miri tests and I was curious why #24 was not failing. I managed to reproduce this by actually trying to make a test that uses `ignore`. The test is failing locally.

```
test regression::issue24::main ... error: Undefined Behavior: pointer to alloc63740 was dereferenced after this allocation got freed
  --> /Users/mitsuhiko/Development/miniserde/src/ignore.rs:7:18
   |
7  |         unsafe { extend_lifetime!(&mut Ignore as &mut Ignore) }
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pointer to alloc63740 was dereferenced after this allocation got freed
   |
   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
```