### PR TITLE
Delete deprecated Error::description implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,4 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "miniserde error"
-    }
-}
+impl std::error::Error for Error {}


### PR DESCRIPTION
This has been unnecessary to implement since rust 1.27 and deprecated to call since rust 1.42.