### PR TITLE
Simplify core::ptr imports

### DIFF
--- a/src/json/array.rs
+++ b/src/json/array.rs
@@ -3,10 +3,7 @@ use alloc::vec::Vec;
 use core::iter::FromIterator;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
-#[cfg(not(feature = "std"))]
 use core::ptr;
-#[cfg(feature = "std")]
-use std::ptr;
 
 /// A `Vec<Value>` with a non-recursive drop impl.
 #[derive(Clone, Debug, Default)]

--- a/src/json/object.rs
+++ b/src/json/object.rs
@@ -8,11 +8,8 @@ use alloc::string::String;
 use core::iter::FromIterator;
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
-#[cfg(not(feature = "std"))]
 use core::ptr;
 use core::str;
-#[cfg(feature = "std")]
-use std::ptr;
 
 /// A `BTreeMap<String, Value>` with a non-recursive drop impl.
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
Unclear why this was done this way in #21. I didn't catch it at the time.