### PR TITLE
WIP - Add venial support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.36"
 [dependencies]
 itoa = "1.0"
 mini-internal = { version = "=0.1.23", path = "derive" }
+miniserde-derive-venial = { path = "derive-venial" }
 ryu = "1.0"
 
 [dev-dependencies]
@@ -25,7 +26,7 @@ serde_json = "1.0"
 trybuild = { version = "1.0.49", features = ["diff"] }
 
 [workspace]
-members = ["derive", "tests/crate"]
+members = ["derive", "derive-venial", "tests/crate"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/derive-venial/Cargo.toml
+++ b/derive-venial/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "miniserde-derive-venial"
+version = "0.1.23"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+license = "MIT OR Apache-2.0"
+description = "Derive macros for miniserde. Use the re-exports from the miniserde crate instead."
+repository = "https://github.com/dtolnay/miniserde"
+documentation = "https://docs.rs/miniserde"
+edition = "2018"
+rust-version = "1.36"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+expander = "0.0.5"
+proc-macro2 = "1.0"
+quote = "1.0.2"
+venial = { path = "../../venial" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/derive-venial/src/attr.rs
+++ b/derive-venial/src/attr.rs
@@ -1,0 +1,54 @@
+use proc_macro2::{Literal, TokenTree};
+use venial::{Attribute, EnumVariant, NamedField};
+
+type MyError = ();
+
+/// Find the value of a #[serde(rename = "...")] attribute.
+fn attr_rename(attributes: &[Attribute]) -> Result<Option<Literal>, MyError> {
+    let mut rename = None;
+
+    for attribute in attributes {
+        match &attribute.child_tokens[0] {
+            TokenTree::Ident(ident) if ident == "serde" => (),
+            _ => continue,
+        }
+
+        if rename.is_some() {
+            panic!("duplicate attribute");
+        }
+
+        let list: Vec<_> = match attribute.child_tokens.get(1) {
+            Some(TokenTree::Group(group)) => group.stream().into_iter().collect(),
+            _ => panic!("unsupported attribute"),
+        };
+
+        match list.get(0) {
+            Some(TokenTree::Ident(ident)) if ident == "rename" => (),
+            _ => panic!("expected rename"),
+        }
+        match list.get(1) {
+            Some(TokenTree::Punct(punct)) if punct.as_char() == '=' => (),
+            _ => panic!("expected ="),
+        };
+        let literal = match list.get(2) {
+            Some(TokenTree::Literal(literal)) => literal,
+            _ => panic!("expected string literal"),
+        };
+
+        rename = Some(literal.clone());
+    }
+
+    Ok(rename)
+}
+
+/// Determine the name of a field, respecting a rename attribute.
+pub fn name_of_field(field: &NamedField) -> Result<Literal, MyError> {
+    let rename = attr_rename(&field.attributes)?;
+    Ok(rename.unwrap_or_else(|| Literal::string(&field.name.to_string())))
+}
+
+/// Determine the name of a variant, respecting a rename attribute.
+pub fn name_of_variant(var: &EnumVariant) -> Result<Literal, MyError> {
+    let rename = attr_rename(&var.attributes)?;
+    Ok(rename.unwrap_or_else(|| Literal::string(&var.name.to_string())))
+}

--- a/derive-venial/src/bound.rs
+++ b/derive-venial/src/bound.rs
@@ -1,0 +1,77 @@
+use proc_macro2::{Punct, Spacing, TokenStream};
+use quote::TokenStreamExt;
+use venial::{
+    Enum, GenericBound, GenericParam, GenericParams, Struct, WhereClause, WhereClauseItem,
+};
+
+// --- TODO - add to venial ---
+
+fn get_type_params(generics: &Option<GenericParams>) -> Vec<GenericParam> {
+    let generics = if let Some(generics) = generics.as_ref() {
+        generics
+    } else {
+        return Vec::new();
+    };
+    generics
+        .params
+        .inner
+        .iter()
+        .map(|(param, _punct)| param)
+        .filter(|param| param._prefix.is_none())
+        .cloned()
+        .collect()
+}
+
+pub fn create_derive_where_clause(
+    generics: &Option<GenericParams>,
+    base_where_clause: &Option<WhereClause>,
+    derived_trait: TokenStream,
+) -> WhereClause {
+    let mut where_clause = base_where_clause.clone().unwrap_or_default();
+
+    for param in get_type_params(generics) {
+        let item = WhereClauseItem {
+            left_side: vec![param.name.clone().into()],
+            bound: GenericBound {
+                _colon: Punct::new(':', Spacing::Alone),
+                tokens: derived_trait.clone().into_iter().collect(),
+            },
+        };
+
+        where_clause = where_clause.with_item(item);
+    }
+
+    where_clause
+}
+
+pub struct InlineGenericArgs<'a>(&'a GenericParams);
+
+#[allow(unused)]
+pub fn as_inline_args(generics: &GenericParams) -> InlineGenericArgs<'_> {
+    InlineGenericArgs(generics)
+}
+
+pub fn get_inline_generic_args_struct(struct_decl: &Struct) -> Option<InlineGenericArgs<'_>> {
+    Some(InlineGenericArgs(struct_decl.generic_params.as_ref()?))
+}
+
+#[allow(unused)]
+pub fn get_inline_generic_args_enum(enum_decl: &Enum) -> Option<InlineGenericArgs<'_>> {
+    Some(InlineGenericArgs(enum_decl.generic_params.as_ref()?))
+}
+
+impl quote::ToTokens for InlineGenericArgs<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Punct::new('<', Spacing::Alone));
+
+        for param in &self.0.params.inner {
+            if param.0.is_lifetime() {
+                param.0._prefix.to_tokens(tokens);
+            }
+            tokens.append(param.0.name.clone());
+            tokens.append(Punct::new(',', Spacing::Alone));
+        }
+
+        tokens.append(Punct::new('>', Spacing::Alone));
+    }
+}

--- a/derive-venial/src/de.rs
+++ b/derive-venial/src/de.rs
@@ -1,0 +1,209 @@
+use crate::{
+    attr,
+    bound::{create_derive_where_clause, get_inline_generic_args_struct},
+};
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+
+use venial::{parse_declaration, Declaration, Enum, GenericParam, Struct, StructFields};
+#[allow(unused)]
+use venial::{
+    Attribute, EnumDiscriminant, EnumVariant, GenericParams, NamedField, TupleField, TyExpr,
+    VisMarker, WhereClause,
+};
+
+type MyError = ();
+
+pub fn derive(input: TokenStream) -> Result<TokenStream, MyError> {
+    let type_decl = parse_declaration(input);
+
+    let res = match &type_decl {
+        Declaration::Struct(struct_decl) => derive_struct(struct_decl)?,
+        Declaration::Enum(enum_decl) => derive_enum(enum_decl)?,
+        _ => panic!("can't parse type"),
+    };
+
+    #[cfg(FALSE)]
+    {
+        return Ok(expander::Expander::new("globalmacro")
+            .add_comment("This is generated code!".to_owned())
+            .dry(false)
+            .verbose(true)
+            .write_to_out_dir(res.clone())
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to write to file: {:?}", e);
+                res
+            }));
+    }
+
+    #[allow(unreachable_code)]
+    Ok(res)
+}
+
+fn derive_struct(struct_decl: &Struct) -> Result<TokenStream, MyError> {
+    let name_ident = &struct_decl.name;
+
+    let dummy = Ident::new(
+        &format!("_IMPL_MINIDESERIALIZE_FOR_{}", name_ident),
+        Span::call_site(),
+    );
+
+    let impl_generics = &struct_decl.generic_params;
+    let inline_generics = get_inline_generic_args_struct(&struct_decl);
+    let bounded_where_clause = create_derive_where_clause(
+        &struct_decl.generic_params,
+        &struct_decl.where_clause,
+        quote!(miniserde::Serialize),
+    );
+
+    let fields = match &struct_decl.fields {
+        StructFields::Unit => panic!("can't parse unit struct"),
+        StructFields::Tuple(_fields) => panic!("can't parse tuple struct"),
+        StructFields::Named(fields) => fields,
+    };
+    let field_names = fields
+        .fields
+        .inner
+        .iter()
+        .map(|field| &field.0.name)
+        .collect::<Vec<_>>();
+    let field_types = fields.fields.inner.iter().map(|field| &field.0.ty);
+    let field_strings: Vec<_> = fields
+        .fields
+        .inner
+        .iter()
+        .map(|field| attr::name_of_field(&field.0))
+        .collect::<Result<Vec<_>, ()>>()?;
+
+    let wrapper_decl = struct_decl
+        .clone()
+        .with_param(GenericParam::lifetime("__a"));
+    let wrapper_impl_generics = &wrapper_decl.generic_params;
+    let wrapper_inline_generics = get_inline_generic_args_struct(&wrapper_decl);
+    let wrapper_where_clause = struct_decl.where_clause.clone();
+
+    Ok(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            #[repr(C)]
+            struct __Visitor #impl_generics #wrapper_where_clause {
+                __out: miniserde::__private::Option<#name_ident #inline_generics>,
+            }
+
+            impl #impl_generics miniserde::Deserialize for #name_ident #inline_generics #bounded_where_clause {
+                fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor {
+                    unsafe {
+                        &mut *{
+                            __out
+                            as *mut miniserde::__private::Option<Self>
+                            as *mut __Visitor #inline_generics
+                        }
+                    }
+                }
+            }
+
+            impl #impl_generics miniserde::de::Visitor for __Visitor #inline_generics #bounded_where_clause {
+                fn map(&mut self) -> miniserde::Result<miniserde::__private::Box<dyn miniserde::de::Map + '_>> {
+                    Ok(miniserde::__private::Box::new(__State {
+                        #(
+                            #field_names: miniserde::Deserialize::default(),
+                        )*
+                        __out: &mut self.__out,
+                    }))
+                }
+            }
+
+            struct __State #wrapper_impl_generics #wrapper_where_clause {
+                #(
+                    #field_names: miniserde::__private::Option<#field_types>,
+                )*
+                __out: &'__a mut miniserde::__private::Option<#name_ident #inline_generics>,
+            }
+
+            impl #wrapper_impl_generics miniserde::de::Map for __State #wrapper_inline_generics #bounded_where_clause {
+                fn key(&mut self, __k: &miniserde::__private::str) -> miniserde::Result<&mut dyn miniserde::de::Visitor> {
+                    match __k {
+                        #(
+                            #field_strings => miniserde::__private::Ok(miniserde::Deserialize::begin(&mut self.#field_names)),
+                        )*
+                        _ => miniserde::__private::Ok(<dyn miniserde::de::Visitor>::ignore()),
+                    }
+                }
+
+                fn finish(&mut self) -> miniserde::Result<()> {
+                    #(
+                        let #field_names = self.#field_names.take().ok_or(miniserde::Error)?;
+                    )*
+                    *self.__out = miniserde::__private::Some(#name_ident {
+                        #(
+                            #field_names,
+                        )*
+                    });
+                    miniserde::__private::Ok(())
+                }
+            }
+        };
+    })
+}
+
+fn derive_enum(enum_decl: &Enum) -> Result<TokenStream, MyError> {
+    if enum_decl.generic_params.is_some() {
+        panic!("Enums with generics are not supported");
+    }
+
+    let name_ident = &enum_decl.name;
+    let dummy = Ident::new(
+        &format!("_IMPL_MINIDESERIALIZE_FOR_{}", name_ident),
+        Span::call_site(),
+    );
+
+    let variant_idents = enum_decl
+        .variants
+        .inner
+        .iter()
+        .map(|variant| match variant.0.contents {
+            StructFields::Unit => Ok(&variant.0.name),
+            _ => panic!("Invalid variant: only simple enum variants without fields are supported"),
+        })
+        .collect::<Result<Vec<_>, MyError>>()?;
+    let variant_names = enum_decl
+        .variants
+        .inner
+        .iter()
+        .map(|variant| attr::name_of_variant(&variant.0))
+        .collect::<Result<Vec<_>, MyError>>()?;
+
+    Ok(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            #[repr(C)]
+            struct __Visitor {
+                __out: miniserde::__private::Option<#name_ident>,
+            }
+
+            impl miniserde::Deserialize for #name_ident {
+                fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor {
+                    unsafe {
+                        &mut *{
+                            __out
+                            as *mut miniserde::__private::Option<Self>
+                            as *mut __Visitor
+                        }
+                    }
+                }
+            }
+
+            impl miniserde::de::Visitor for __Visitor {
+                fn string(&mut self, s: &miniserde::__private::str) -> miniserde::Result<()> {
+                    let value = match s {
+                        #( #variant_names => #name_ident::#variant_idents, )*
+                        _ => return miniserde::__private::Err(miniserde::Error),
+                    };
+                    self.__out = miniserde::__private::Some(value);
+                    miniserde::__private::Ok(())
+                }
+            }
+        };
+    })
+}

--- a/derive-venial/src/lib.rs
+++ b/derive-venial/src/lib.rs
@@ -1,0 +1,24 @@
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::needless_pass_by_value,
+    clippy::unseparated_literal_suffix
+)]
+
+extern crate proc_macro;
+
+mod attr;
+mod bound;
+mod de;
+mod ser;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Serialize, attributes(serde))]
+pub fn derive_serialize(input: TokenStream) -> TokenStream {
+    ser::derive(input.into()).unwrap().into()
+}
+
+#[proc_macro_derive(Deserialize, attributes(serde))]
+pub fn derive_deserialize(input: TokenStream) -> TokenStream {
+    de::derive(input.into()).unwrap().into()
+}

--- a/derive-venial/src/ser.rs
+++ b/derive-venial/src/ser.rs
@@ -1,0 +1,184 @@
+use crate::{
+    attr,
+    bound::{create_derive_where_clause, get_inline_generic_args_struct},
+};
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use venial::{parse_declaration, Declaration, Enum, GenericParam, Struct, StructFields};
+#[allow(unused)]
+use venial::{
+    Attribute, EnumDiscriminant, EnumVariant, GenericParams, NamedField, TupleField, TyExpr,
+    VisMarker, WhereClause,
+};
+
+type MyError = ();
+
+pub fn derive(input: TokenStream) -> Result<TokenStream, MyError> {
+    let type_decl = parse_declaration(input);
+
+    let res = match &type_decl {
+        Declaration::Struct(struct_decl) => derive_struct(struct_decl)?,
+        Declaration::Enum(enum_decl) => derive_enum(enum_decl)?,
+        _ => panic!("can't parse type"),
+    };
+
+    #[cfg(FALSE)]
+    {
+        return Ok(expander::Expander::new("globalmacro")
+            .add_comment("This is generated code!".to_owned())
+            .dry(false)
+            .verbose(true)
+            .write_to_out_dir(res.clone())
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to write to file: {:?}", e);
+                res
+            }));
+    }
+
+    #[allow(unreachable_code)]
+    Ok(res)
+}
+
+fn derive_struct(struct_decl: &Struct) -> Result<TokenStream, MyError> {
+    let name_ident = &struct_decl.name;
+
+    let dummy = Ident::new(
+        &format!("_IMPL_MINISERIALIZE_FOR_{}", name_ident),
+        Span::call_site(),
+    );
+
+    let impl_generics = &struct_decl.generic_params;
+    let inline_generics = get_inline_generic_args_struct(&struct_decl);
+    let bounded_where_clause = create_derive_where_clause(
+        &struct_decl.generic_params,
+        &struct_decl.where_clause,
+        quote!(miniserde::Serialize),
+    );
+
+    let fields = match &struct_decl.fields {
+        StructFields::Unit => panic!("can't parse unit struct"),
+        StructFields::Tuple(_fields) => panic!("can't parse tuple struct"),
+        StructFields::Named(fields) => fields,
+    };
+    let field_names = fields
+        .fields
+        .inner
+        .iter()
+        .map(|field| &field.0.name)
+        .collect::<Vec<_>>();
+    let field_strings: Vec<_> = fields
+        .fields
+        .inner
+        .iter()
+        .map(|field| attr::name_of_field(&field.0))
+        .collect::<Result<Vec<_>, ()>>()?;
+    let indices = 0usize..;
+
+    let wrapper_decl = struct_decl
+        .clone()
+        .with_param(GenericParam::lifetime("__a"));
+    let wrapper_impl_generics = &wrapper_decl.generic_params;
+    let wrapper_inline_generics = get_inline_generic_args_struct(&wrapper_decl);
+    let wrapper_where_clause = struct_decl.where_clause.clone();
+
+    Ok(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            impl #impl_generics miniserde::Serialize for #name_ident #inline_generics #bounded_where_clause {
+                fn begin(&self) -> miniserde::ser::Fragment {
+                    miniserde::ser::Fragment::Map(miniserde::__private::Box::new(__Map {
+                        data: self,
+                        state: 0,
+                    }))
+                }
+            }
+
+            struct __Map #wrapper_impl_generics #wrapper_where_clause {
+                data: &'__a #name_ident #inline_generics,
+                state: miniserde::__private::usize,
+            }
+
+            impl #wrapper_impl_generics miniserde::ser::Map for __Map #wrapper_inline_generics #bounded_where_clause {
+                fn next(&mut self) -> miniserde::__private::Option<(miniserde::__private::Cow<miniserde::__private::str>, &dyn miniserde::Serialize)> {
+                    let __state = self.state;
+                    self.state = __state + 1;
+                    match __state {
+                        #(
+                            #indices => miniserde::__private::Some((
+                                miniserde::__private::Cow::Borrowed(#field_strings),
+                                &self.data.#field_names,
+                            )),
+                        )*
+                        _ => miniserde::__private::None,
+                    }
+                }
+            }
+        };
+    })
+}
+
+fn derive_enum(enum_decl: &Enum) -> Result<TokenStream, MyError> {
+    if enum_decl.generic_params.is_some() {
+        panic!("Enums with generics are not supported");
+    }
+
+    let name_ident = &enum_decl.name;
+    let dummy = Ident::new(
+        &format!("_IMPL_MINISERIALIZE_FOR_{}", name_ident),
+        Span::call_site(),
+    );
+
+    let variant_idents = enum_decl
+        .variants
+        .inner
+        .iter()
+        .map(|variant| match variant.0.contents {
+            StructFields::Unit => Ok(&variant.0.name),
+            _ => panic!("Invalid variant: only simple enum variants without fields are supported"),
+        })
+        .collect::<Result<Vec<_>, MyError>>()?;
+    let variant_names = enum_decl
+        .variants
+        .inner
+        .iter()
+        .map(|variant| attr::name_of_variant(&variant.0))
+        .collect::<Result<Vec<_>, MyError>>()?;
+
+    Ok(quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy: () = {
+            impl miniserde::Serialize for #name_ident {
+                fn begin(&self) -> miniserde::ser::Fragment {
+                    match self {
+                        #(
+                            #name_ident::#variant_idents => {
+                                miniserde::ser::Fragment::Str(miniserde::__private::Cow::Borrowed(#variant_names))
+                            }
+                        )*
+                    }
+                }
+            }
+        };
+    })
+}
+
+#[test]
+fn test_basic_struct() {
+    let _ = derive(quote!(
+        struct Hello {
+            a: A,
+            b: B,
+        }
+    ));
+}
+
+#[test]
+fn test_basic_enum() {
+    let _ = derive(quote!(
+        enum Tag {
+            A,
+            B,
+        }
+    ));
+}

--- a/tests/test_venial.rs
+++ b/tests/test_venial.rs
@@ -1,0 +1,68 @@
+use miniserde::json;
+use miniserde_derive_venial::{Deserialize, Serialize};
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+enum Tag {
+    A,
+    #[serde(rename = "renamedB")]
+    B,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct Example {
+    x: String,
+    t1: Tag,
+    t2: Box<Tag>,
+    n: Box<Nested>,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct Example2<
+    Foo: miniserde::Deserialize + miniserde::Serialize,
+    Bar: miniserde::Deserialize + miniserde::Serialize,
+> {
+    x: String,
+    foo: Foo,
+    bar: Bar,
+    t1: Tag,
+    t2: Box<Tag>,
+    n: Box<Nested>,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+struct Nested {
+    y: Option<Vec<String>>,
+    z: Option<String>,
+}
+
+#[test]
+fn test_ser() {
+    let example = Example {
+        x: "X".to_owned(),
+        t1: Tag::A,
+        t2: Box::new(Tag::B),
+        n: Box::new(Nested {
+            y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
+            z: None,
+        }),
+    };
+    let actual = json::to_string(&example);
+    let expected = r#"{"x":"X","t1":"A","t2":"renamedB","n":{"y":["Y","Y"],"z":null}}"#;
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn test_de() {
+    let j = r#" {"x": "X", "t1": "A", "t2": "renamedB", "n": {"y": ["Y", "Y"]}} "#;
+    let actual: Example = json::from_str(j).unwrap();
+    let expected = Example {
+        x: "X".to_owned(),
+        t1: Tag::A,
+        t2: Box::new(Tag::B),
+        n: Box::new(Nested {
+            y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
+            z: None,
+        }),
+    };
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
This is more of a showcase than a serious PR for now.

This shows how derive macros like `Serialize` and `Deserialize` can use venial instead of syn to parse type declarations. Feedback welcome.