### PR TITLE
Switch to using primitives in macro-generated code through core::primitive

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -2,12 +2,5 @@ pub use alloc::borrow::Cow;
 pub use alloc::boxed::Box;
 pub use alloc::string::String;
 pub use core::option::Option::{self, None, Some};
+pub use core::primitive::{str, usize};
 pub use core::result::Result::{Err, Ok};
-
-pub use self::help::Str as str;
-pub use self::help::Usize as usize;
-
-mod help {
-    pub type Str = str;
-    pub type Usize = usize;
-}


### PR DESCRIPTION
`core::primitive` has been stable since Rust 1.43.