### PR TITLE
Fix static_mut_ref warning

### DIFF
--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,21 +1,17 @@
 use crate::de::{Map, Seq, Visitor};
 use crate::error::Result;
 use alloc::boxed::Box;
+use core::ptr;
 
 impl dyn Visitor {
     pub fn ignore() -> &'static mut dyn Visitor {
         static mut IGNORE: Ignore = Ignore;
-        unsafe { &mut IGNORE }
-        //
-        // The following may be needed if stacked borrows gets more selective
-        // about the above in the future:
-        //
-        //     unsafe { &mut *ptr::addr_of_mut!(IGNORE) }
-        //
+
         // Conceptually we have an array of type [Ignore; ∞] in a static, which
         // is zero sized, and each caller of `fn ignore` gets a unique one of
         // them, as if by `&mut *ptr::addr_of_mut!(IGNORE[i++])` for some
         // appropriately synchronized i.
+        unsafe { &mut *ptr::addr_of_mut!(IGNORE) }
     }
 }
 


### PR DESCRIPTION
New in nightly-2024-01-10 due to https://github.com/rust-lang/rust/pull/117556.

```console
warning: mutable reference of mutable static is discouraged
 --> src/ignore.rs:8:18
  |
8 |         unsafe { &mut IGNORE }
  |                  ^^^^^^^^^^^ mutable reference of mutable static
  |
  = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
  = note: reference of mutable static is a hard error from 2024 edition
  = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
  = note: `#[warn(static_mut_ref)]` on by default
help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
  |
8 |         unsafe { addr_of_mut!(IGNORE) }
  |                  ~~~~~~~~~~~~~~~~~~~~
```