### PR TITLE
Resolve non_local_definitions warnings in rustc 1.78-nightly

### DIFF
--- a/derive/src/de.rs
+++ b/derive/src/de.rs
@@ -2,7 +2,7 @@ use crate::{attr, bound};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-    parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Ident, Result,
+    parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Result,
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
@@ -26,10 +26,6 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStream> {
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let dummy = Ident::new(
-        &format!("_IMPL_MINIDESERIALIZE_FOR_{}", ident),
-        Span::call_site(),
-    );
 
     let fieldname = fields.named.iter().map(|f| &f.ident).collect::<Vec<_>>();
     let fieldty = fields.named.iter().map(|f| &f.ty);
@@ -46,7 +42,7 @@ pub fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenS
 
     Ok(quote! {
         #[allow(non_upper_case_globals)]
-        const #dummy: () = {
+        const _: () = {
             #[repr(C)]
             struct __Visitor #impl_generics #where_clause {
                 __out: miniserde::__private::Option<#ident #ty_generics>,
@@ -117,10 +113,6 @@ pub fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenS
     }
 
     let ident = &input.ident;
-    let dummy = Ident::new(
-        &format!("_IMPL_MINIDESERIALIZE_FOR_{}", ident),
-        Span::call_site(),
-    );
 
     let var_idents = enumeration
         .variants
@@ -141,7 +133,7 @@ pub fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenS
 
     Ok(quote! {
         #[allow(non_upper_case_globals)]
-        const #dummy: () = {
+        const _: () = {
             #[repr(C)]
             struct __Visitor {
                 __out: miniserde::__private::Option<#ident>,

--- a/derive/src/ser.rs
+++ b/derive/src/ser.rs
@@ -2,7 +2,7 @@ use crate::{attr, bound};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-    parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Ident, Result,
+    parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Result,
 };
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
@@ -26,10 +26,6 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStream> {
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let dummy = Ident::new(
-        &format!("_IMPL_MINISERIALIZE_FOR_{}", ident),
-        Span::call_site(),
-    );
 
     let fieldname = &fields.named.iter().map(|f| &f.ident).collect::<Vec<_>>();
     let fieldstr = fields
@@ -46,7 +42,7 @@ fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStrea
 
     Ok(quote! {
         #[allow(non_upper_case_globals)]
-        const #dummy: () = {
+        const _: () = {
             impl #impl_generics miniserde::Serialize for #ident #ty_generics #bounded_where_clause {
                 fn begin(&self) -> miniserde::ser::Fragment {
                     miniserde::ser::Fragment::Map(miniserde::__private::Box::new(__Map {
@@ -89,10 +85,6 @@ fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenStrea
     }
 
     let ident = &input.ident;
-    let dummy = Ident::new(
-        &format!("_IMPL_MINISERIALIZE_FOR_{}", ident),
-        Span::call_site(),
-    );
 
     let var_idents = enumeration
         .variants
@@ -113,7 +105,7 @@ fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenStrea
 
     Ok(quote! {
         #[allow(non_upper_case_globals)]
-        const #dummy: () = {
+        const _: () = {
             impl miniserde::Serialize for #ident {
                 fn begin(&self) -> miniserde::ser::Fragment {
                     match self {

--- a/src/json/array.rs
+++ b/src/json/array.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::json::{drop, Value};
 use crate::private;
 use crate::ser::{Fragment, Serialize};
-use crate::Place;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
@@ -113,6 +112,8 @@ impl Serialize for Array {
 
 impl Deserialize for Array {
     fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+        make_place!(Place);
+
         impl Visitor for Place<Array> {
             fn seq(&mut self) -> Result<Box<dyn Seq + '_>> {
                 Ok(Box::new(ArrayBuilder {

--- a/src/json/number.rs
+++ b/src/json/number.rs
@@ -1,7 +1,6 @@
 use crate::de::{Deserialize, Visitor};
 use crate::error::Result;
 use crate::ser::{Fragment, Serialize};
-use crate::Place;
 use core::fmt::{self, Display};
 
 /// A JSON number represented by some Rust primitive.
@@ -34,6 +33,8 @@ impl Serialize for Number {
 
 impl Deserialize for Number {
     fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+        make_place!(Place);
+
         impl Visitor for Place<Number> {
             fn negative(&mut self, n: i64) -> Result<()> {
                 self.out = Some(Number::I64(n));

--- a/src/json/object.rs
+++ b/src/json/object.rs
@@ -2,7 +2,6 @@ use crate::de::{Deserialize, Map, Visitor};
 use crate::error::Result;
 use crate::json::{drop, Value};
 use crate::ser::{self, Fragment, Serialize};
-use crate::Place;
 use alloc::borrow::{Cow, ToOwned};
 use alloc::boxed::Box;
 use alloc::collections::{btree_map, BTreeMap};
@@ -116,6 +115,8 @@ impl Serialize for Object {
 
 impl Deserialize for Object {
     fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+        make_place!(Place);
+
         impl Visitor for Place<Object> {
             fn map(&mut self) -> Result<Box<dyn Map + '_>> {
                 Ok(Box::new(ObjectBuilder {

--- a/src/json/value.rs
+++ b/src/json/value.rs
@@ -2,7 +2,6 @@ use crate::de::{Deserialize, Map, Seq, Visitor};
 use crate::error::Result;
 use crate::json::{Array, Number, Object};
 use crate::ser::{Fragment, Serialize};
-use crate::Place;
 use alloc::borrow::{Cow, ToOwned};
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -72,6 +71,8 @@ impl Serialize for Value {
 
 impl Deserialize for Value {
     fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+        make_place!(Place);
+
         impl Visitor for Place<Value> {
             fn null(&mut self) -> Result<()> {
                 self.out = Some(Value::Null);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,5 @@ pub use crate::error::{Error, Result};
 #[doc(inline)]
 pub use crate::ser::Serialize;
 
-make_place!(Place);
-
 #[allow(non_camel_case_types)]
 struct private;


### PR DESCRIPTION
```console
warning: non-local `impl` definition, they should be avoided as they go against expectation
  --> src/de/impls.rs:21:9
   |
21 | /         impl Visitor for Place<()> {
22 | |             fn null(&mut self) -> Result<()> {
23 | |                 self.out = Some(());
24 | |                 Ok(())
25 | |             }
26 | |         }
   | |_________^
   |
   = help: move this `impl` block outside the of the current associated function `begin`
   = note: an `impl` definition is non-local if it is nested inside an item and neither the type nor the trait are at the same nesting level as the `impl` block
   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
   = note: `#[warn(non_local_definitions)]` on by default
```