### PR TITLE
Emit impls even in the presence of bad attributes

### DIFF
--- a/derive/src/de.rs
+++ b/derive/src/de.rs
@@ -1,11 +1,21 @@
-use crate::{attr, bound};
+use crate::{attr, bound, fallback};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
     parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, FieldsNamed, Result,
 };
 
-pub fn derive(input: &DeriveInput) -> Result<TokenStream> {
+pub fn derive(input: &DeriveInput) -> TokenStream {
+    match try_expand(input) {
+        Ok(expanded) => expanded,
+        // If there are invalid attributes in the input, expand to a Deserialize
+        // impl anyway to minimize spurious secondary errors in other code that
+        // deserializes this type.
+        Err(error) => fallback::de(input, error),
+    }
+}
+
+fn try_expand(input: &DeriveInput) -> Result<TokenStream> {
     match &input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(fields),

--- a/derive/src/fallback.rs
+++ b/derive/src/fallback.rs
@@ -1,0 +1,39 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+
+pub(crate) fn ser(input: &DeriveInput, error: syn::Error) -> TokenStream {
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let error = error.into_compile_error();
+
+    quote! {
+        #error
+
+        #[allow(deprecated)]
+        impl #impl_generics miniserde::Serialize for #ident #ty_generics #where_clause {
+            fn begin(&self) -> miniserde::ser::Fragment {
+                miniserde::__private::unreachable!()
+            }
+        }
+    }
+}
+
+pub(crate) fn de(input: &DeriveInput, error: syn::Error) -> TokenStream {
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let error = error.into_compile_error();
+
+    quote! {
+        #error
+
+        #[allow(deprecated)]
+        impl #impl_generics miniserde::Deserialize for #ident #ty_generics #where_clause {
+            fn begin(__out: &mut miniserde::__private::Option<Self>) -> &mut dyn miniserde::de::Visitor {
+                miniserde::__private::unreachable!()
+            }
+        }
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -9,6 +9,7 @@ extern crate proc_macro;
 mod attr;
 mod bound;
 mod de;
+mod fallback;
 mod ser;
 
 use proc_macro::TokenStream;
@@ -17,15 +18,11 @@ use syn::{parse_macro_input, DeriveInput};
 #[proc_macro_derive(Serialize, attributes(serde))]
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    ser::derive(&input)
-        .unwrap_or_else(|err| err.to_compile_error())
-        .into()
+    ser::derive(&input).into()
 }
 
 #[proc_macro_derive(Deserialize, attributes(serde))]
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    de::derive(&input)
-        .unwrap_or_else(|err| err.to_compile_error())
-        .into()
+    de::derive(&input).into()
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,6 +4,8 @@
 pub use core::option::Option::{None, Some};
 #[doc(hidden)]
 pub use core::result::Result::{Err, Ok};
+#[doc(hidden)]
+pub use core::unreachable;
 
 #[doc(hidden)]
 pub type Box<T> = alloc::boxed::Box<T>;


### PR DESCRIPTION
This minimizes spurious errors popping up in downstream code while attributes in a miniserde data structure are being edited.